### PR TITLE
[76] Fix typed parameters and multi-space properties in animation profile parser

### DIFF
--- a/server/app/vfg/parser/Animation_parser.py
+++ b/server/app/vfg/parser/Animation_parser.py
@@ -106,10 +106,10 @@ def parse_visual(text_to_parse, result):
     # Get the value of properties
     temp_property_block = temp_visual_block[temp_visual_block.index(pattern_properties) + len(pattern_properties):]
     temp_property_block = Parser_Functions.get_one_block(temp_property_block)
-    temp_properties_pattern = re.compile("\([a-zA-Z0-9_.-]*\s[#a-zA-Z0-9_.-]*\)")
+    temp_properties_pattern = re.compile(r"\([a-zA-Z0-9_.-]*\s+[#a-zA-Z0-9_.-]+\)")
     temp_properties = temp_properties_pattern.findall(temp_property_block)
     for x in temp_properties:
-        x, y = x.replace('(', '').replace(')', '').split()
+        x, y = x.replace('(', '').replace(')', '').split()       
         sublist[x] = y
     result["visual"][temp_subshape_value] = sublist
     return result;

--- a/server/app/vfg/parser/Animation_parser.py
+++ b/server/app/vfg/parser/Animation_parser.py
@@ -163,7 +163,7 @@ def parse_predicate(text_to_parse, result):
 
     # Get the value of parameters
     temp_regex_pattern = re.compile(pattern_parameters + " " + "\((.*?)\)", re.IGNORECASE)
-    objectList = temp_regex_pattern.findall(temp_visual_block)[0].split()
+    objectList = [t for t in temp_regex_pattern.findall(temp_visual_block)[0].split() if t.startswith('?')]
 
     customObjectList = parseObjectLine(pattern_custom, temp_visual_block)
     # Get the value of effect


### PR DESCRIPTION
## Summary

- **Typed parameters**: PDDL predicates with typed parameters (e.g. `(?r - robot ?l - location)`) caused a logic error because `:parameters` was split verbatim, including `-` and type names. Now filters to tokens starting with `?` so only parameter names are kept; untyped profiles are unaffected.
- **Multi-space properties**: The properties regex `\s` matched exactly one space, so entries written with extra whitespace (e.g. `(width  36)`) were silently dropped from the visual block and never reached `objects_dic`. Changed to `\s+` to allow one or more spaces, and `+` instead of `*` for the value group to require a non-empty value.

## Test plan

- [x] Animation profile with typed parameters (e.g. `(?r - robot ?l - location)`) parses correctly — only `?r`, `?l` in `objectList`
- [x] Visual properties with multiple spaces (e.g. `(width  36)`) appear in `animation_profile["visual"]` and propagate to `stageitems`
- [x] Existing untyped animation profiles and single-space properties continue to work unchanged

Resolves #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)